### PR TITLE
Allow users to opt in to seeing phonetics along with syllabary

### DIFF
--- a/src/components/NavigationBar.tsx
+++ b/src/components/NavigationBar.tsx
@@ -76,8 +76,8 @@ export function NavigationBar(): ReactElement {
         </StyledNavLink>
       </StyledNav>
       <AdvancedSettings>
-        <StyledNavLink as={NavLink} to="/developer-tools">
-          Developers
+        <StyledNavLink as={NavLink} to="/settings">
+          Settings
         </StyledNavLink>
       </AdvancedSettings>
     </NavbarWrapper>

--- a/src/components/SectionHeading.tsx
+++ b/src/components/SectionHeading.tsx
@@ -5,4 +5,5 @@ export const SectionHeading = styled.h2`
   font-size: ${theme.fontSizes.md};
   color: ${theme.colors.TEXT_GRAY};
   margin: 0;
+  margin-bottom: 8px;
 `;

--- a/src/components/exercises/SimpleFlashcards.tsx
+++ b/src/components/exercises/SimpleFlashcards.tsx
@@ -12,6 +12,7 @@ import { TermCardWithStats } from "../../spaced-repetition/types";
 import { useUserStateContext } from "../../state/UserStateProvider";
 import { theme } from "../../theme";
 import { createIssueForAudioInNewTab } from "../../utils/createIssue";
+import { getPhonetics } from "../../utils/phonetics";
 import { useAudio } from "../../utils/useAudio";
 import { ExerciseComponentProps } from "./Exercise";
 
@@ -57,7 +58,7 @@ const StyledFlashcardBody = styled.button`
   margin: 30px auto;
   padding: 8px;
   box-shadow: 1px 1px 8px #666;
-  display: flex;
+  display: block;
   align-items: center;
   outline: none;
   p {
@@ -74,12 +75,16 @@ export function Flashcard({
   card: TermCardWithStats<Card>;
   reviewCurrentCard: (correct: boolean) => void;
 }) {
-  const { groupId } = useUserStateContext();
+  const { groupId, phoneticsPreference } = useUserStateContext();
   const [cardFlipped, setCardFlipped] = useState(false);
   const [startSide, setStartSide] = useState<"cherokee" | "english">(
     "cherokee"
   );
   const [side, setSide] = useState(startSide);
+  const phonetics = useMemo(
+    () => getPhonetics(card.card, phoneticsPreference),
+    [card]
+  );
 
   function flipCard() {
     console.log("Flipping card...");
@@ -132,7 +137,7 @@ export function Flashcard({
     ];
   }, [card]);
 
-  const { play, playing } = useAudio({
+  const { play } = useAudio({
     src: side === "cherokee" ? cherokeeAudio : englishAudio,
     autoplay: true,
   });
@@ -150,6 +155,16 @@ export function Flashcard({
       </form>
       <StyledFlashcardBody onClick={() => flipCard()}>
         <p>{side === "cherokee" ? card.card.syllabary : card.card.english}</p>
+        {phonetics && side === "cherokee" && (
+          <p
+            style={{
+              fontFamily:
+                "sans-serif" /** need to have font support combining diacritic marks (eg. double acute accent i̋) */,
+            }}
+          >
+            {phonetics}
+          </p>
+        )}
       </StyledFlashcardBody>
       <FlashcardControls playAudio={play} reviewCard={reviewCardOrFlip} />
       <button onClick={() => createIssueForAudioInNewTab(groupId, card.term)}>

--- a/src/components/exercises/SimpleFlashcards.tsx
+++ b/src/components/exercises/SimpleFlashcards.tsx
@@ -83,7 +83,7 @@ export function Flashcard({
   const [side, setSide] = useState(startSide);
   const phonetics = useMemo(
     () => getPhonetics(card.card, phoneticsPreference),
-    [card]
+    [card, phoneticsPreference]
   );
 
   function flipCard() {
@@ -155,16 +155,7 @@ export function Flashcard({
       </form>
       <StyledFlashcardBody onClick={() => flipCard()}>
         <p>{side === "cherokee" ? card.card.syllabary : card.card.english}</p>
-        {phonetics && side === "cherokee" && (
-          <p
-            style={{
-              fontFamily:
-                "sans-serif" /** need to have font support combining diacritic marks (eg. double acute accent i̋) */,
-            }}
-          >
-            {phonetics}
-          </p>
-        )}
+        {phonetics && side === "cherokee" && <p>{phonetics}</p>}
       </StyledFlashcardBody>
       <FlashcardControls playAudio={play} reviewCard={reviewCardOrFlip} />
       <button onClick={() => createIssueForAudioInNewTab(groupId, card.term)}>

--- a/src/data/cards.ts
+++ b/src/data/cards.ts
@@ -48,10 +48,7 @@ export const cards: Card[] = mergeSets(
 );
 
 export function cherokeeToKey(cherokee: string) {
-  return cherokee
-    .trim()
-    .toLowerCase()
-    .replaceAll(/[\.\?\,]/g, "");
+  return cherokee.trim().toLowerCase().replaceAll(/[.?,]/g, "");
 }
 
 export function keyForCard(card: Card): string {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -16,7 +16,7 @@ import { PracticeLesson } from "./views/practice/PracticeLesson";
 import { NewLesson } from "./views/lessons/NewLesson";
 import { ViewCollection } from "./views/collections/ViewCollection";
 import { MyTerms } from "./views/terms/MyTerms";
-import { DeveloperTools } from "./views/developer-tools/DeveloperTools";
+import { Settings } from "./views/settings/Settings";
 
 const root = ReactDOM.createRoot(
   document.getElementById("root") as HTMLElement
@@ -54,7 +54,7 @@ root.render(
               <Route index element={<Navigate to="/lessons/" replace />} />
               <Route path=":lessonId/*" element={<PracticeLesson />}></Route>
             </Route>
-            <Route path="developer-tools" element={<DeveloperTools />} />
+            <Route path="settings" element={<Settings />} />
           </Route>
         </Routes>
       </UserStateProvider>

--- a/src/state/UserStateProvider.tsx
+++ b/src/state/UserStateProvider.tsx
@@ -29,10 +29,7 @@ import { UserStateAction } from "./actions";
 import { LessonCreationError } from "./reducers/lessons/createNewLesson";
 import { GroupId, GROUPS, isGroupId, reduceGroupId } from "./reducers/groupId";
 import { GroupRegistrationModal } from "../components/GroupRegistrationModal";
-import {
-  PhoneticsPreference,
-  reducePhoneticsPreference,
-} from "./reducers/phoneticsPreference";
+import { PhoneticsPreference } from "./reducers/phoneticsPreference";
 
 export interface UserStateProps {
   leitnerBoxes: {
@@ -78,6 +75,19 @@ function reduceUpstreamCollection(
     // if no upstream collection, set to group default
     return upstreamCollection ?? GROUPS[action.groupId].defaultCollectionId;
   else return upstreamCollection;
+}
+
+function reducePhoneticsPreference(
+  state: UserState,
+  action: UserStateAction
+): PhoneticsPreference | undefined {
+  if (action.type === "SET_PHONETICS_PREFERENCE") return action.newPreference;
+  if (action.type === "REGISTER_GROUP_AND_APPLY_DEFAULTS")
+    // if no preference, set to group default when a user registers
+    return (
+      state.phoneticsPreference ?? GROUPS[action.groupId].phoneticsPreference
+    );
+  else return state.phoneticsPreference;
 }
 
 function reduceLessonCreationError(

--- a/src/state/UserStateProvider.tsx
+++ b/src/state/UserStateProvider.tsx
@@ -29,6 +29,10 @@ import { UserStateAction } from "./actions";
 import { LessonCreationError } from "./reducers/lessons/createNewLesson";
 import { GroupId, GROUPS, isGroupId, reduceGroupId } from "./reducers/groupId";
 import { GroupRegistrationModal } from "../components/GroupRegistrationModal";
+import {
+  PhoneticsPreference,
+  reducePhoneticsPreference,
+} from "./reducers/phoneticsPreference";
 
 export interface UserStateProps {
   leitnerBoxes: {
@@ -49,11 +53,14 @@ export interface UserState {
   upstreamCollection: string | undefined;
   /** Group registration */
   groupId: GroupId | undefined;
+  /** Preference for how phonetics are shown */
+  phoneticsPreference: PhoneticsPreference | undefined;
 }
 
 interface MiscInteractors {
   setUpstreamCollection: (collectionId: string) => void;
   registerGroup: (groupId: string) => void;
+  setPhoneticsPreference: (newPreference: PhoneticsPreference) => void;
   loadState: (state: UserState) => void;
 }
 
@@ -92,6 +99,7 @@ function reduceUserState(state: UserState, action: UserStateAction): UserState {
     upstreamCollection: reduceUpstreamCollection(state, action),
     lessonCreationError: reduceLessonCreationError(state, action),
     groupId: reduceGroupId(state, action),
+    phoneticsPreference: reducePhoneticsPreference(state, action),
   };
 }
 
@@ -114,6 +122,7 @@ function initializeUserState({
       upstreamCollection: undefined,
       lessonCreationError: undefined,
       groupId: undefined,
+      phoneticsPreference: undefined,
     };
 }
 
@@ -167,6 +176,12 @@ export function useUserState(props: {
           state,
         });
         dispatch({ type: "HANDLE_SET_CHANGES" });
+      },
+      setPhoneticsPreference(newPreference) {
+        dispatch({
+          type: "SET_PHONETICS_PREFERENCE",
+          newPreference,
+        });
       },
     }),
     []

--- a/src/state/UserStateProvider.tsx
+++ b/src/state/UserStateProvider.tsx
@@ -74,7 +74,7 @@ function reduceUpstreamCollection(
   action: UserStateAction
 ): string | undefined {
   if (action.type === "SET_UPSTREAM_COLLECTION") return action.newCollectionId;
-  if (action.type === "REGISTER_GROUP")
+  if (action.type === "REGISTER_GROUP_AND_APPLY_DEFAULTS")
     // if no upstream collection, set to group default
     return upstreamCollection ?? GROUPS[action.groupId].defaultCollectionId;
   else return upstreamCollection;
@@ -165,7 +165,7 @@ export function useUserState(props: {
       registerGroup(groupId: string) {
         if (isGroupId(groupId)) {
           dispatch({
-            type: "REGISTER_GROUP",
+            type: "REGISTER_GROUP_AND_APPLY_DEFAULTS",
             groupId,
           });
         }
@@ -196,6 +196,12 @@ export function useUserState(props: {
       leitnerBoxesInteractors.resize(
         props.initializationProps.leitnerBoxes.numBoxes
       );
+    if (state.groupId) {
+      dispatch({
+        groupId: state.groupId,
+        type: "REGISTER_GROUP_AND_APPLY_DEFAULTS",
+      });
+    }
     dispatch({ type: "HANDLE_SET_CHANGES" });
   }, []);
 

--- a/src/state/actions.ts
+++ b/src/state/actions.ts
@@ -28,7 +28,7 @@ export type SetUpstreamCollectionAction = {
 };
 
 export type RegisterWithGroupAction = {
-  type: "REGISTER_GROUP";
+  type: "REGISTER_GROUP_AND_APPLY_DEFAULTS";
   groupId: GroupId;
 };
 

--- a/src/state/actions.ts
+++ b/src/state/actions.ts
@@ -2,6 +2,7 @@ import { GroupId, GROUPS } from "./reducers/groupId";
 import { ReviewResult } from "./reducers/leitnerBoxes";
 import { Lesson } from "./reducers/lessons";
 import { LessonCreationError } from "./reducers/lessons/createNewLesson";
+import { PhoneticsPreference } from "./reducers/phoneticsPreference";
 import { UserState } from "./UserStateProvider";
 
 export type ResizeLeitnerBoxesAction = {
@@ -67,6 +68,12 @@ export type HandleSetChangesAction = {
   type: "HANDLE_SET_CHANGES";
 };
 
+// FIXME: I think 'preferences' could get moved into a separate part of the codebase so this doesn't keep getting longer
+export type SetPhoneticsPreferenceAction = {
+  type: "SET_PHONETICS_PREFERENCE";
+  newPreference: PhoneticsPreference;
+};
+
 export type UserStateAction =
   | SetUpstreamCollectionAction
   | RegisterWithGroupAction
@@ -74,4 +81,5 @@ export type UserStateAction =
   | ResizeLeitnerBoxesAction
   | SetAction
   | LessonsAction
-  | HandleSetChangesAction;
+  | HandleSetChangesAction
+  | SetPhoneticsPreferenceAction;

--- a/src/state/reducers/groupId.ts
+++ b/src/state/reducers/groupId.ts
@@ -36,6 +36,7 @@ export function reduceGroupId(
   state: UserState,
   action: UserStateAction
 ): GroupId | undefined {
-  if (action.type === "REGISTER_GROUP") return action.groupId;
+  if (action.type === "REGISTER_GROUP_AND_APPLY_DEFAULTS")
+    return action.groupId;
   else return state.groupId;
 }

--- a/src/state/reducers/groupId.ts
+++ b/src/state/reducers/groupId.ts
@@ -1,10 +1,12 @@
 import { SEE_SAY_WRITE_COLLECTION } from "../../data/vocabSets";
 import { UserStateAction } from "../actions";
 import { UserState } from "../UserStateProvider";
+import { PhoneticsPreference } from "./phoneticsPreference";
 
 export interface Group {
   name: string;
   defaultCollectionId?: string;
+  phoneticsPreference?: PhoneticsPreference;
 }
 
 export const OPEN_BETA_ID = "03e2ec2d-4877-48d7-96c1-c74a907c65ae";
@@ -13,6 +15,7 @@ const __groups = {
   "3f1089ca-57c5-4d85-ba44-289b896c0f6e": {
     name: "Cherokee Community of Puget Sound Beginners Group",
     defaultCollectionId: SEE_SAY_WRITE_COLLECTION,
+    phoneticsPreference: PhoneticsPreference.Simple,
   },
   [OPEN_BETA_ID]: {
     name: "Open beta (not affiliated)",

--- a/src/state/reducers/phoneticsPreference.ts
+++ b/src/state/reducers/phoneticsPreference.ts
@@ -1,6 +1,6 @@
 import { UserStateAction } from "../actions";
 import { UserState } from "../UserStateProvider";
-import { GroupId } from "./groupId";
+import { GROUPS } from "./groupId";
 
 export enum PhoneticsPreference {
   NoPhonetics = "NO_PHONETICS",
@@ -26,5 +26,10 @@ export function reducePhoneticsPreference(
   action: UserStateAction
 ): PhoneticsPreference | undefined {
   if (action.type === "SET_PHONETICS_PREFERENCE") return action.newPreference;
+  if (action.type === "REGISTER_GROUP")
+    // if no preference, set to group default when a user registers
+    return (
+      state.phoneticsPreference ?? GROUPS[action.groupId].phoneticsPreference
+    );
   else return state.phoneticsPreference;
 }

--- a/src/state/reducers/phoneticsPreference.ts
+++ b/src/state/reducers/phoneticsPreference.ts
@@ -1,7 +1,3 @@
-import { UserStateAction } from "../actions";
-import { UserState } from "../UserStateProvider";
-import { GROUPS } from "./groupId";
-
 export enum PhoneticsPreference {
   NoPhonetics = "NO_PHONETICS",
   Simple = "SIMPLE",
@@ -10,7 +6,7 @@ export enum PhoneticsPreference {
 
 export const PREFERENCE_LITERATES: Record<PhoneticsPreference, string> = {
   NO_PHONETICS: "Do not show phonetics if syllabary is shown.",
-  SIMPLE: "Show phonetics broken up by syllable. Eg. 'A-hyv-da-gwa-lo-s-gi'",
+  SIMPLE: "Show phonetics without tone or vowel length. Eg. 'Ahyvdagwalosgi'",
   DETAILED:
     "Show rich phonetics that show vowel length and tone. Eg. 'Ahyv:dagwalò:sgi'",
 };
@@ -19,17 +15,4 @@ export function isPhoneticsPreference(str: string): str is PhoneticsPreference {
   // we can't do "hasOwn" on PhoneticsPreference because it also contains
   // reverse mapping ("NO_PHONETICS": "NoPhonetics")
   return Object.hasOwn(PREFERENCE_LITERATES, str);
-}
-
-export function reducePhoneticsPreference(
-  state: UserState,
-  action: UserStateAction
-): PhoneticsPreference | undefined {
-  if (action.type === "SET_PHONETICS_PREFERENCE") return action.newPreference;
-  if (action.type === "REGISTER_GROUP_AND_APPLY_DEFAULTS")
-    // if no preference, set to group default when a user registers
-    return (
-      state.phoneticsPreference ?? GROUPS[action.groupId].phoneticsPreference
-    );
-  else return state.phoneticsPreference;
 }

--- a/src/state/reducers/phoneticsPreference.ts
+++ b/src/state/reducers/phoneticsPreference.ts
@@ -26,7 +26,7 @@ export function reducePhoneticsPreference(
   action: UserStateAction
 ): PhoneticsPreference | undefined {
   if (action.type === "SET_PHONETICS_PREFERENCE") return action.newPreference;
-  if (action.type === "REGISTER_GROUP")
+  if (action.type === "REGISTER_GROUP_AND_APPLY_DEFAULTS")
     // if no preference, set to group default when a user registers
     return (
       state.phoneticsPreference ?? GROUPS[action.groupId].phoneticsPreference

--- a/src/state/reducers/phoneticsPreference.ts
+++ b/src/state/reducers/phoneticsPreference.ts
@@ -1,0 +1,30 @@
+import { UserStateAction } from "../actions";
+import { UserState } from "../UserStateProvider";
+import { GroupId } from "./groupId";
+
+export enum PhoneticsPreference {
+  NoPhonetics = "NO_PHONETICS",
+  Simple = "SIMPLE",
+  Detailed = "DETAILED",
+}
+
+export const PREFERENCE_LITERATES: Record<PhoneticsPreference, string> = {
+  NO_PHONETICS: "Do not show phonetics if syllabary is shown.",
+  SIMPLE: "Show phonetics broken up by syllable. Eg. 'A-hyv-da-gwa-lo-s-gi'",
+  DETAILED:
+    "Show rich phonetics that show vowel length and tone. Eg. 'Ahyv:dagwalò:sgi'",
+};
+
+export function isPhoneticsPreference(str: string): str is PhoneticsPreference {
+  // we can't do "hasOwn" on PhoneticsPreference because it also contains
+  // reverse mapping ("NO_PHONETICS": "NoPhonetics")
+  return Object.hasOwn(PREFERENCE_LITERATES, str);
+}
+
+export function reducePhoneticsPreference(
+  state: UserState,
+  action: UserStateAction
+): PhoneticsPreference | undefined {
+  if (action.type === "SET_PHONETICS_PREFERENCE") return action.newPreference;
+  else return state.phoneticsPreference;
+}

--- a/src/state/reducers/phoneticsPreference.ts
+++ b/src/state/reducers/phoneticsPreference.ts
@@ -6,9 +6,9 @@ export enum PhoneticsPreference {
 
 export const PREFERENCE_LITERATES: Record<PhoneticsPreference, string> = {
   NO_PHONETICS: "Do not show phonetics if syllabary is shown.",
-  SIMPLE: "Show phonetics without tone or vowel length. Eg. 'Ahyvdagwalosgi'",
+  SIMPLE: "Show phonetics without tone or vowel length. Eg. 'ahyvdagwalosgi'",
   DETAILED:
-    "Show rich phonetics that show vowel length and tone. Eg. 'Ahyv:dagwalò:sgi'",
+    "Show rich phonetics that show vowel length and tone. Eg. 'a²hyv²²da²gwa²lo¹¹sgi'",
 };
 
 export function isPhoneticsPreference(str: string): str is PhoneticsPreference {

--- a/src/state/useUserState.test.ts
+++ b/src/state/useUserState.test.ts
@@ -93,6 +93,7 @@ describe("useUserState", () => {
             sets: {},
             upstreamCollection: undefined,
             groupId: undefined,
+            phoneticsPreference: undefined,
           },
           initializationProps: {
             leitnerBoxes: {
@@ -178,6 +179,7 @@ describe("useUserState", () => {
         sets: {},
         upstreamCollection: undefined,
         groupId: undefined,
+        phoneticsPreference: undefined,
       });
     });
 

--- a/src/utils/phonetics.test.ts
+++ b/src/utils/phonetics.test.ts
@@ -1,13 +1,18 @@
 import assert from "assert";
-import { removeTonesAndMarkers } from "./phonetics";
+import {
+  normalizeAndRemovePunctuation,
+  removeTonesAndMarkers,
+} from "./phonetics";
 
 describe("removeTonesAndVowelLength", () => {
   it.each([
     ["sǔ:dáli", "sudali"],
-    ["sa:sa aná:ɂi", "sasa anai"],
-    ["U:ni:ji:ya dù:hyoha na asgaya", "Unijiya duhyoha na asgaya"],
+    ["Sa:sa aná:ɂi", "sasa anai"],
+    ["U:ni:ji:ya dù:hyoha na asgaya", "unijiya duhyoha na asgaya"],
   ])("works for a bunch of examples", (richPhonetics, expected) => {
-    const actual = removeTonesAndMarkers(richPhonetics);
+    const actual = removeTonesAndMarkers(
+      normalizeAndRemovePunctuation(richPhonetics)
+    );
     assert.deepStrictEqual(actual, expected, "Should produce expected output");
   });
 });

--- a/src/utils/phonetics.test.ts
+++ b/src/utils/phonetics.test.ts
@@ -1,0 +1,13 @@
+import assert from "assert";
+import { removeTonesAndMarkers } from "./phonetics";
+
+describe("removeTonesAndVowelLength", () => {
+  it.each([
+    ["sǔ:dáli", "sudali"],
+    ["sa:sa aná:ɂi", "sasa anai"],
+    ["U:ni:ji:ya dù:hyoha na asgaya", "Unijiya duhyoha na asgaya"],
+  ])("works for a bunch of examples", (richPhonetics, expected) => {
+    const actual = removeTonesAndMarkers(richPhonetics);
+    assert.deepStrictEqual(actual, expected, "Should produce expected output");
+  });
+});

--- a/src/utils/phonetics.test.ts
+++ b/src/utils/phonetics.test.ts
@@ -1,18 +1,64 @@
 import assert from "assert";
 import {
+  mcoToWebsterTones,
   normalizeAndRemovePunctuation,
   removeTonesAndMarkers,
 } from "./phonetics";
 
-describe("removeTonesAndVowelLength", () => {
+describe("normalization and tone removal", () => {
   it.each([
-    ["sǔ:dáli", "sudali"],
-    ["Sa:sa aná:ɂi", "sasa anai"],
-    ["U:ni:ji:ya dù:hyoha na asgaya", "unijiya duhyoha na asgaya"],
-  ])("works for a bunch of examples", (richPhonetics, expected) => {
-    const actual = removeTonesAndMarkers(
-      normalizeAndRemovePunctuation(richPhonetics)
-    );
-    assert.deepStrictEqual(actual, expected, "Should produce expected output");
-  });
+    ["sǔ:dáli", "sǔ:dáli".normalize("NFKD"), "sudali"],
+    ["Sa:sa aná:ɂi", "sa:sa aná:ɂi".normalize("NFKD"), "sasa anaɂi"],
+    [
+      "U:ni:ji:ya dù:hyoha na asgaya",
+      "u:ni:tsi:ya dù:hyoha na asgaya".normalize("NFKD"),
+      "unitsiya duhyoha na asgaya",
+    ],
+    [
+      "na yǒ:na achű:ja já:ni dù:dó:ʔa",
+      "na yǒ:na atsű:tsa tsá:ni dù:dó:ɂa".normalize("NFKD"),
+      "na yona atsutsa tsani dudoɂa",
+    ],
+  ])(
+    "works for a bunch of examples",
+    (richPhonetics, expectedNormalized, expectedSimplified) => {
+      const actualNormalized = normalizeAndRemovePunctuation(richPhonetics);
+      assert.deepStrictEqual(
+        actualNormalized,
+        expectedNormalized,
+        "Should produce expected normalized output"
+      );
+
+      const actualSimplified = removeTonesAndMarkers(actualNormalized);
+      assert.deepStrictEqual(
+        actualSimplified,
+        expectedSimplified,
+        "Should produce expected simplified output"
+      );
+    }
+  );
+});
+
+describe("mcoToWebsterTones", () => {
+  it.each([
+    ["sǔ:dáli", "su²³da³li"],
+    ["sadv́:di à:gowhtíha", "sa²dv³³di a¹¹go²whti³ha"],
+    [
+      "na yǒ:na achű:ja já:ni dù:dó:ʔa",
+      "na yo²³na a²tsu⁴⁴tsa tsa³³ni du¹¹do³³ɂa",
+    ],
+    ["Ahyv:dagwalò:sgi", "a²hyv²²da²gwa²lo¹¹sgi"],
+    ["Ayv:wi:ya̋", "a²yv²²wi²²ya⁴"],
+  ])(
+    "converts from diacritic- to superscript-based orthographies",
+    (mco, expected) => {
+      const normalized = normalizeAndRemovePunctuation(mco);
+      const actual = mcoToWebsterTones(normalized);
+      assert.deepStrictEqual(
+        actual,
+        expected,
+        "Should produce expected output"
+      );
+    }
+  );
 });

--- a/src/utils/phonetics.ts
+++ b/src/utils/phonetics.ts
@@ -1,0 +1,39 @@
+import { Card } from "../data/cards";
+import { PhoneticsPreference } from "../state/reducers/phoneticsPreference";
+
+export function getPhonetics(
+  card: Card,
+  phoneticsPreference: PhoneticsPreference | undefined
+): string {
+  return getRawPhonetics(card, phoneticsPreference).normalize("NFKC");
+}
+
+function getRawPhonetics(
+  card: Card,
+  phoneticsPreference: PhoneticsPreference | undefined
+): string {
+  switch (phoneticsPreference) {
+    case PhoneticsPreference.Detailed:
+      return normalizeAndRemovePunctuation(card.cherokee);
+    case PhoneticsPreference.Simple:
+      return simplifyPhonetics(card.cherokee);
+    case undefined:
+    case PhoneticsPreference.NoPhonetics:
+      return "";
+  }
+}
+
+export function normalizeAndRemovePunctuation(cherokee: string): string {
+  return cherokee
+    .toLowerCase()
+    .replaceAll(/[\.\?]/g, "")
+    .normalize("NFKD");
+}
+
+export function removeTonesAndMarkers(cherokee: string): string {
+  return cherokee.replace(/[\:ɂ\u0300-\u036f]/g, "");
+}
+
+export function simplifyPhonetics(cherokee: string): string {
+  return removeTonesAndMarkers(normalizeAndRemovePunctuation(cherokee));
+}

--- a/src/utils/phonetics.ts
+++ b/src/utils/phonetics.ts
@@ -5,7 +5,7 @@ export function getPhonetics(
   card: Card,
   phoneticsPreference: PhoneticsPreference | undefined
 ): string {
-  return getRawPhonetics(card, phoneticsPreference).normalize("NFKC");
+  return getRawPhonetics(card, phoneticsPreference).normalize("NFC");
 }
 
 function getRawPhonetics(
@@ -14,7 +14,7 @@ function getRawPhonetics(
 ): string {
   switch (phoneticsPreference) {
     case PhoneticsPreference.Detailed:
-      return normalizeAndRemovePunctuation(card.cherokee);
+      return mcoToWebsterTones(normalizeAndRemovePunctuation(card.cherokee));
     case PhoneticsPreference.Simple:
       return simplifyPhonetics(card.cherokee);
     case undefined:
@@ -26,12 +26,31 @@ function getRawPhonetics(
 export function normalizeAndRemovePunctuation(cherokee: string): string {
   return cherokee
     .toLowerCase()
-    .replaceAll(/[\.\?]/g, "")
+    .replaceAll(/[.?]/g, "")
+    .replaceAll(/(ch)|(j)/g, "ts")
+    .replaceAll(/qu/g, "gw")
+    .replaceAll(/[Ɂʔ]/g, "ɂ")
     .normalize("NFKD");
 }
 
+export function mcoToWebsterTones(cherokee: string): string {
+  // ¹²³⁴
+  // conversion based on Uchihara 2013, p. 14
+  return cherokee
+    .replaceAll(/([aeiouv])\u0300:/g, "$1¹¹") // combining grave accent, long
+    .replaceAll(/([aeiouv]):/g, "$1²²") // long vowel with no diacritic
+    .replaceAll(/([aeiouv])\u0301:/g, "$1³³") // combining acute accent, long
+    .replaceAll(/([aeiouv])\u030C:/g, "$1²³") // combining caron accent, long
+    .replaceAll(/([aeiouv])\u0302:/g, "$1³²") // combining circumflex accent, long
+    .replaceAll(/([aeiouv])\u030B:/g, "$1⁴⁴") // combining double acute accent, long
+    .replaceAll(/([aeiouv])\u030B/g, "$1⁴") // combining double acute accent, short (in cases where a final vowel is dropped and a highfall tone must become short)
+    .replaceAll(/([aeiouv])\u0300/g, "$1¹") // combining grave accent, short
+    .replaceAll(/([aeiouv])\u0301/g, "$1³") // combining acute accent, short
+    .replaceAll(/([aeiouv])(?![¹²³⁴]|\W|$)/g, "$1²"); // vowel not followed by any tone yet
+}
+
 export function removeTonesAndMarkers(cherokee: string): string {
-  return cherokee.replace(/[\:ɂ\u0300-\u036f]/g, "");
+  return cherokee.replace(/[:\u0300-\u036f]/g, "");
 }
 
 export function simplifyPhonetics(cherokee: string): string {

--- a/src/views/settings/Settings.tsx
+++ b/src/views/settings/Settings.tsx
@@ -1,11 +1,11 @@
 import { ChangeEvent, useId, useState } from "react";
 import { useNavigate } from "react-router-dom";
+import styled from "styled-components";
 import { Button } from "../../components/Button";
 import { SectionHeading } from "../../components/SectionHeading";
 import { lessonKey } from "../../state/reducers/lessons";
 import {
   isPhoneticsPreference,
-  PhoneticsPreference,
   PREFERENCE_LITERATES,
 } from "../../state/reducers/phoneticsPreference";
 import { UserState, useUserStateContext } from "../../state/UserStateProvider";
@@ -17,6 +17,62 @@ interface ExportedLessonData {
 }
 
 export function Settings() {
+  return (
+    <div>
+      <Preferences />
+      <br />
+      <hr />
+      <p>
+        <em>
+          Settings below this point might not be much use to you unless a
+          maintainer of this website contacted you.
+        </em>
+      </p>
+      <ImportExportDataConsole />
+    </div>
+  );
+}
+
+const PreferencesForm = styled.form`
+  display: grid;
+  grid-template-columns: auto 1fr;
+  grid-gap: 8px;
+`;
+
+function Preferences() {
+  const { setPhoneticsPreference, phoneticsPreference } = useUserStateContext();
+  const phoneticsPreferenceId = useId();
+
+  function onPhoneticsPreferenceChanged(event: ChangeEvent<HTMLSelectElement>) {
+    event.preventDefault();
+    const newPreference = event.target.value;
+    if (isPhoneticsPreference(newPreference)) {
+      setPhoneticsPreference(newPreference);
+    }
+  }
+
+  return (
+    <div>
+      <SectionHeading>Preferences</SectionHeading>
+      <PreferencesForm>
+        <label htmlFor={phoneticsPreferenceId}>Phonetics preference</label>
+        <select
+          id={phoneticsPreferenceId}
+          value={phoneticsPreference}
+          onChange={onPhoneticsPreferenceChanged}
+        >
+          {Object.entries(PREFERENCE_LITERATES).map(([value, literate], i) => (
+            <option key={i} value={value}>
+              {literate}
+            </option>
+          ))}
+        </select>
+      </PreferencesForm>
+    </div>
+  );
+}
+
+function ImportExportDataConsole() {
   const userState = useUserStateContext();
   const [fileToLoad, setFileToLoad] = useState<File | null>(null);
   const navigate = useNavigate();
@@ -96,38 +152,8 @@ export function Settings() {
         navigate("/");
       });
   }
-
-  const phoneticsPreferenceId = useId();
-  function onPhoneticsPreferenceChanged(event: ChangeEvent<HTMLSelectElement>) {
-    event.preventDefault();
-    const newPreference = event.target.value;
-    if (isPhoneticsPreference(newPreference)) {
-      userState.setPhoneticsPreference(newPreference);
-    }
-  }
-
   return (
     <div>
-      <SectionHeading>Settings</SectionHeading>
-      <form>
-        <label htmlFor={phoneticsPreferenceId}>Phonetics preference</label>
-        <select
-          id={phoneticsPreferenceId}
-          value={userState.phoneticsPreference}
-          onChange={onPhoneticsPreferenceChanged}
-        >
-          {Object.entries(PREFERENCE_LITERATES).map(([value, literate], i) => (
-            <option key={i} value={value}>
-              {literate}
-            </option>
-          ))}
-        </select>
-      </form>
-      <hr />
-      <p>
-        Settings below this point might not be much use to you unless a
-        maintainer of this website contacted you.
-      </p>
       <SectionHeading>Export data</SectionHeading>
       <Button onClick={downloadAllData}>Download all data</Button>
       <br />

--- a/src/views/settings/Settings.tsx
+++ b/src/views/settings/Settings.tsx
@@ -1,8 +1,13 @@
-import { ChangeEvent, useState } from "react";
+import { ChangeEvent, useId, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { Button } from "../../components/Button";
 import { SectionHeading } from "../../components/SectionHeading";
 import { lessonKey } from "../../state/reducers/lessons";
+import {
+  isPhoneticsPreference,
+  PhoneticsPreference,
+  PREFERENCE_LITERATES,
+} from "../../state/reducers/phoneticsPreference";
 import { UserState, useUserStateContext } from "../../state/UserStateProvider";
 
 interface ExportedLessonData {
@@ -11,7 +16,7 @@ interface ExportedLessonData {
   timings: string | null;
 }
 
-export function DeveloperTools() {
+export function Settings() {
   const userState = useUserStateContext();
   const [fileToLoad, setFileToLoad] = useState<File | null>(null);
   const navigate = useNavigate();
@@ -27,6 +32,7 @@ export function DeveloperTools() {
       sets: null,
       upstreamCollection: null,
       groupId: null,
+      phoneticsPreference: null,
     };
 
     const stateToSave = Object.keys(fieldsToSave).reduce(
@@ -91,16 +97,41 @@ export function DeveloperTools() {
       });
   }
 
+  const phoneticsPreferenceId = useId();
+  function onPhoneticsPreferenceChanged(event: ChangeEvent<HTMLSelectElement>) {
+    event.preventDefault();
+    const newPreference = event.target.value;
+    if (isPhoneticsPreference(newPreference)) {
+      userState.setPhoneticsPreference(newPreference);
+    }
+  }
+
   return (
     <div>
-      <SectionHeading>Developer tools</SectionHeading>
+      <SectionHeading>Settings</SectionHeading>
+      <form>
+        <label htmlFor={phoneticsPreferenceId}>Phonetics preference</label>
+        <select
+          id={phoneticsPreferenceId}
+          value={userState.phoneticsPreference}
+          onChange={onPhoneticsPreferenceChanged}
+        >
+          {Object.entries(PREFERENCE_LITERATES).map(([value, literate], i) => (
+            <option key={i} value={value}>
+              {literate}
+            </option>
+          ))}
+        </select>
+      </form>
+      <hr />
       <p>
-        These settings probably aren't much use to you unless a maintainer of
-        this website contacted you.
+        Settings below this point might not be much use to you unless a
+        maintainer of this website contacted you.
       </p>
       <SectionHeading>Export data</SectionHeading>
       <Button onClick={downloadAllData}>Download all data</Button>
-      <hr />
+      <br />
+      <br />
       <SectionHeading>Import data</SectionHeading>
       <form onSubmit={loadData}>
         <label htmlFor="loadDataFile">Select a file to load data from</label>


### PR DESCRIPTION
Adds a user setting for displaying phonetics alongside syllabary.

# Reason

New learners are often uncomfortable with the syllabary

# Implementation
- Add a new `phoneticsPreference` field to `UserState`
- Default value set via group registration *
- Can be edited in user settings

\* This required making it so group registration happens every time on site load, which maybe should be tested more. In short, we just need to be sure all reducers that respond to the `GROUP_REGISTRATION` action are _idempotent_ (will only affect things the first time they are run)

# Potential issues
- In order to get rich phonetics to render eg. `Ahyv:dagwalò:sgi` required finding a font that can handle weird diacritics (accents on top of letters), meaning the phonetics are _not_ in the same font as the rest of the site