### PR TITLE
Add mouseover syllabary and phonetics highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
 
+## Removing terms and updating phonetics for existing terms
+
+If you need to update a vocab set and your updates will include _changing the written phonetics_ for the terms in the set, you need to write a **migration**. **THIS INCLUDES CHANGES THAT REMOVE TERMS**. These are files found in the [src/data/migrations](src/data/migrations) folder. Import `addMigration` and call it with a dictionary that maps `oldPhonetics` to `newPhonetics`. This ensures terms being tracked for a user are properly transfered to the new phonetics based key when they load the site after the changes deploy. (This system is cobbled together and totally needs love.)
+
 ## Available Scripts
 
 In the project directory, you can run:

--- a/src/components/exercises/SimpleFlashcards.tsx
+++ b/src/components/exercises/SimpleFlashcards.tsx
@@ -12,7 +12,10 @@ import { TermCardWithStats } from "../../spaced-repetition/types";
 import { useUserStateContext } from "../../state/UserStateProvider";
 import { theme } from "../../theme";
 import { createIssueForTermInNewTab } from "../../utils/createIssue";
-import { getPhonetics } from "../../utils/phonetics";
+import {
+  alignSyllabaryAndPhonetics,
+  getPhonetics,
+} from "../../utils/phonetics";
 import { useAudio } from "../../utils/useAudio";
 import { ExerciseComponentProps } from "./Exercise";
 
@@ -61,6 +64,10 @@ const StyledFlashcardBody = styled.button`
   display: block;
   align-items: center;
   outline: none;
+  background: ${theme.colors.LIGHTER_GRAY};
+  &:hover {
+    background: ${theme.colors.LIGHT_GRAY};
+  }
   p {
     flex: 1;
     text-align: center;
@@ -154,14 +161,87 @@ export function Flashcard({
         </select>
       </form>
       <StyledFlashcardBody onClick={() => flipCard()}>
-        <p>{side === "cherokee" ? card.card.syllabary : card.card.english}</p>
-        {phonetics && side === "cherokee" && <p>{phonetics}</p>}
+        {side === "english" ? (
+          <p>{card.card.english}</p>
+        ) : (
+          <AlignedCherokee
+            syllabary={card.card.syllabary}
+            phonetics={phonetics}
+          ></AlignedCherokee>
+        )}
       </StyledFlashcardBody>
       <FlashcardControls playAudio={play} reviewCard={reviewCardOrFlip} />
       <button onClick={() => createIssueForTermInNewTab(groupId, card.term)}>
         Flag an issue with this term
       </button>
     </FlashcardWrapper>
+  );
+}
+
+function AlignedCherokee({
+  syllabary,
+  phonetics,
+}: {
+  syllabary: string;
+  phonetics: string | undefined;
+}): ReactElement {
+  const [alignedSyllabaryWords, alignedPhoneticWords] = useMemo(
+    () =>
+      phonetics
+        ? alignSyllabaryAndPhonetics(syllabary, phonetics)
+        : [syllabary.split(" ").map((word) => word.split("")), []],
+    [syllabary, phonetics]
+  );
+  const [[hoveredWordIdx, hoveredSegmentIdx], setHoveredIdx] = useState<
+    [number | null, number | null]
+  >([null, null]);
+  return (
+    <div>
+      <p>
+        {alignedSyllabaryWords.map((word, wordIdx) => (
+          <>
+            {wordIdx === 0 ? "" : " "}
+            {word.map((segment, segmentIdx) => (
+              <span
+                onMouseOver={() => setHoveredIdx([wordIdx, segmentIdx])}
+                onMouseOut={() => setHoveredIdx([null, null])}
+                style={{
+                  color:
+                    hoveredWordIdx === wordIdx &&
+                    hoveredSegmentIdx === segmentIdx
+                      ? "red"
+                      : "black",
+                }}
+              >
+                {segment}
+              </span>
+            ))}
+          </>
+        ))}
+      </p>
+      <p>
+        {alignedPhoneticWords.map((word, wordIdx) => (
+          <>
+            {wordIdx === 0 ? "" : " "}
+            {word.map((segment, segmentIdx) => (
+              <span
+                onMouseOver={() => setHoveredIdx([wordIdx, segmentIdx])}
+                onMouseOut={() => setHoveredIdx([null, null])}
+                style={{
+                  color:
+                    hoveredWordIdx === wordIdx &&
+                    hoveredSegmentIdx === segmentIdx
+                      ? "red"
+                      : "black",
+                }}
+              >
+                {segment}
+              </span>
+            ))}
+          </>
+        ))}
+      </p>
+    </div>
   );
 }
 

--- a/src/components/exercises/SimpleFlashcards.tsx
+++ b/src/components/exercises/SimpleFlashcards.tsx
@@ -55,23 +55,32 @@ const FlashcardWrapper = styled.div`
 `;
 
 const StyledFlashcardBody = styled.button`
-  border: 1px solid #333;
-  width: 300px;
+  border: none;
+  border-radius: 8px;
+  width: 100%;
   min-height: 200px;
   margin: 30px auto;
   padding: 8px;
-  box-shadow: 1px 1px 8px #666;
   display: block;
   align-items: center;
   outline: none;
-  background: ${theme.colors.LIGHTER_GRAY};
+  background: none;
+  transition: box-shadow 0.1s linear;
+  box-shadow: 1px 1px 0px #6660;
   &:hover {
-    background: ${theme.colors.LIGHT_GRAY};
+    /* border: 1px solid #333; */
+    box-shadow: 1px 1px 5px #666;
+    /* background: ${theme.colors.LIGHTER_GRAY}; */
   }
   p {
     flex: 1;
     text-align: center;
     font-size: ${theme.fontSizes.lg};
+  }
+  mark {
+    background: none;
+    color: red;
+    text-decoration: underline;
   }
 `;
 
@@ -113,7 +122,8 @@ export function Flashcard({
     }
   }
 
-  useKeyPressEvent(" ", () => {
+  useKeyPressEvent(" ", (event) => {
+    event.preventDefault(); // sometimes button will try to get clicked too
     flipCard();
   });
 
@@ -178,6 +188,39 @@ export function Flashcard({
   );
 }
 
+function AlignedTextRow({
+  words,
+  setHoveredIdx,
+  hoveredIdx: [hoveredWordIdx, hoveredSegmentIdx],
+}: {
+  words: string[][];
+  hoveredIdx: [number | null, number | null];
+  setHoveredIdx: (idx: [number | null, number | null]) => void;
+}) {
+  return (
+    <p>
+      {words.map((word, wordIdx) => (
+        <>
+          {wordIdx === 0 ? "" : " "}
+          {word.map((segment, segmentIdx) => (
+            <span
+              onMouseOver={() => setHoveredIdx([wordIdx, segmentIdx])}
+              onMouseOut={() => setHoveredIdx([null, null])}
+            >
+              {hoveredWordIdx === wordIdx &&
+              hoveredSegmentIdx === segmentIdx ? (
+                <mark>{segment}</mark>
+              ) : (
+                segment
+              )}
+            </span>
+          ))}
+        </>
+      ))}
+    </p>
+  );
+}
+
 function AlignedCherokee({
   syllabary,
   phonetics,
@@ -192,55 +235,27 @@ function AlignedCherokee({
         : [syllabary.split(" ").map((word) => word.split("")), []],
     [syllabary, phonetics]
   );
-  const [[hoveredWordIdx, hoveredSegmentIdx], setHoveredIdx] = useState<
-    [number | null, number | null]
-  >([null, null]);
+  const [hoveredIdx, setHoveredIdx] = useState<[number | null, number | null]>([
+    null,
+    null,
+  ]);
   return (
     <div>
-      <p>
-        {alignedSyllabaryWords.map((word, wordIdx) => (
-          <>
-            {wordIdx === 0 ? "" : " "}
-            {word.map((segment, segmentIdx) => (
-              <span
-                onMouseOver={() => setHoveredIdx([wordIdx, segmentIdx])}
-                onMouseOut={() => setHoveredIdx([null, null])}
-                style={{
-                  color:
-                    hoveredWordIdx === wordIdx &&
-                    hoveredSegmentIdx === segmentIdx
-                      ? "red"
-                      : "black",
-                }}
-              >
-                {segment}
-              </span>
-            ))}
-          </>
-        ))}
-      </p>
-      <p>
-        {alignedPhoneticWords.map((word, wordIdx) => (
-          <>
-            {wordIdx === 0 ? "" : " "}
-            {word.map((segment, segmentIdx) => (
-              <span
-                onMouseOver={() => setHoveredIdx([wordIdx, segmentIdx])}
-                onMouseOut={() => setHoveredIdx([null, null])}
-                style={{
-                  color:
-                    hoveredWordIdx === wordIdx &&
-                    hoveredSegmentIdx === segmentIdx
-                      ? "red"
-                      : "black",
-                }}
-              >
-                {segment}
-              </span>
-            ))}
-          </>
-        ))}
-      </p>
+      <AlignedTextRow
+        words={alignedSyllabaryWords}
+        setHoveredIdx={setHoveredIdx}
+        hoveredIdx={hoveredIdx}
+      />
+      {phonetics && (
+        <>
+          <hr />
+          <AlignedTextRow
+            words={alignedPhoneticWords}
+            setHoveredIdx={setHoveredIdx}
+            hoveredIdx={hoveredIdx}
+          />
+        </>
+      )}
     </div>
   );
 }

--- a/src/data/collections/ssw-cards.json
+++ b/src/data/collections/ssw-cards.json
@@ -1934,7 +1934,7 @@
   {
     "alternate_pronunciations": [],
     "alternate_syllabary": [],
-    "cherokee": "Gwiligi dù:do:ɂa achű:ja.",
+    "cherokee": "Gwiligi dù:do:ɂa hiɂa achű:ja.",
     "cherokee_audio": [
       "online-exercises-audio/0813-Lessons51_to_60-000324475.mp3"
     ],
@@ -2382,7 +2382,7 @@
   {
     "alternate_pronunciations": [],
     "alternate_syllabary": [],
-    "cherokee": "De:jv̋ysdv dekdlǒ:hi.",
+    "cherokee": "De:jv̋sdv dekdlǒ:hi.",
     "cherokee_audio": [
       "online-exercises-audio/0971-Lessons71_to_84-000075485.mp3"
     ],
@@ -2536,7 +2536,7 @@
   {
     "alternate_pronunciations": [],
     "alternate_syllabary": [],
-    "cherokee": "Agwa̋:sa wigě:dô:li dida:náɂnv̋ɂi.",
+    "cherokee": "Agwa̋:sa widagě:dô:li dida:náɂnv̋ɂi.",
     "cherokee_audio": [
       "online-exercises-audio/1016-Lessons71_to_84-000209275.mp3"
     ],

--- a/src/data/collections/ssw-cards.json
+++ b/src/data/collections/ssw-cards.json
@@ -1873,7 +1873,7 @@
       "source/en/the_time_is_nine_thirty_Kendra_f9b953bddd22b5dce5879155b2762b2d26390855.mp3",
       "source/en/the_time_is_nine_thirty_Joey_f9b953bddd22b5dce5879155b2762b2d26390855.mp3"
     ],
-    "syllabary": "ᏐᏁᎳ ᎠᏰᏟ ᎠᏟᎵᎢ"
+    "syllabary": "ᏐᏁᎳ ᎠᏰᏟ ᎠᏟᎢᎵ"
   },
   {
     "alternate_pronunciations": [],
@@ -2125,7 +2125,7 @@
       "source/en/he_or_she_is_wearing_a_green_shi_Kendra_e6b9782fe126a94c5774d14a0021c89c39778a0b.mp3",
       "source/en/he_or_she_is_wearing_a_green_shi_Joey_e6b9782fe126a94c5774d14a0021c89c39778a0b.mp3"
     ],
-    "syllabary": "ᎢᏤᏳᏍᏗ ᎤᎵᏑᏫᏓ ᎤᏄᏩ"
+    "syllabary": "ᎢᏤᎢᏳᏍᏗ ᎤᎵᏑᏫᏓ ᎤᏄᏩ"
   },
   {
     "alternate_pronunciations": [],
@@ -2279,7 +2279,7 @@
       "source/en/lets_go_hunt_for_some_wild_onion_Kendra_c4692ded79f74a6c0a58b92e9ecd07973eff7dad.mp3",
       "source/en/lets_go_hunt_for_some_wild_onion_Joey_c4692ded79f74a6c0a58b92e9ecd07973eff7dad.mp3"
     ],
-    "syllabary": "ᏒᎩ ᎢᎾᎨᎡᎯ ᎩᏂᏯᎷᎦ"
+    "syllabary": "ᏒᎩ ᎢᎾᎨ ᎡᎯ ᎩᏂᏯᎷᎦ"
   },
   {
     "alternate_pronunciations": [],
@@ -2335,7 +2335,7 @@
       "source/en/i_hear_a_pigeon_cooing_Kendra_b1ab83bef414826a3fe272bee5a1b6c78c4b9a50.mp3",
       "source/en/i_hear_a_pigeon_cooing_Joey_b1ab83bef414826a3fe272bee5a1b6c78c4b9a50.mp3"
     ],
-    "syllabary": "ᏬᏱ ᏂᎦᏁᏍᎬ ᎦᏛᎩᎠ"
+    "syllabary": "ᏬᏱ ᏂᎦᏪᏍᎬ ᎦᏛᎩᎠ"
   },
   {
     "alternate_pronunciations": [],
@@ -2769,7 +2769,7 @@
       "source/en/moses_is_spoken_of_in_mark_chapt_Kendra_fc360968edff7440f4c2bfd2359adbf97220f33d.mp3",
       "source/en/moses_is_spoken_of_in_mark_chapt_Joey_fc360968edff7440f4c2bfd2359adbf97220f33d.mp3"
     ],
-    "syllabary": "ᎹᏚ ᏐᏁᎵᏁ ᎠᏯᏙᏢ ᎠᏥᏃᎮᎭ ᎼᏏ"
+    "syllabary": "ᎹᎦ ᏐᏁᎵᏁ ᎠᏯᏙᏢ ᎠᏥᏃᎮᎭ ᎼᏏ"
   },
   {
     "alternate_pronunciations": [],

--- a/src/data/collections/ssw.json
+++ b/src/data/collections/ssw.json
@@ -174,7 +174,7 @@
         "Hila̋ ǐ:ga̋ juwě:ji dejadu:lí?",
         "Hila̋ iyú:de:tiyv̋:da hiɂa achű:ja.",
         "Ju:ni:là:wisdi̋ idè:na.",
-        "Gwiligi dù:do:ɂa achű:ja."
+        "Gwiligi dù:do:ɂa hiɂa achű:ja."
       ]
     },
     {
@@ -218,7 +218,7 @@
         "Gaɂlo:hni kaɂlv̋ anvnsgó unitelvládi.",
         "Íhě:dô:lv:ɂi.",
         "Ajvgalí:yé:di ga:nǐ:dô:ha.",
-        "De:jv̋ysdv dekdlǒ:hi.",
+        "De:jv̋sdv dekdlǒ:hi.",
         "Hi:yo:lì:gis kilő dludlu jù:do:ɂǐ:da?",
         "Ada ti:sdlû:hya.",
         "Ha:dlv dajì:hluni hiɂa gǎ:da?",
@@ -229,7 +229,7 @@
         "Hlawò:tu:hi̋ nigalsdi:sgó yù:ga:hnana.",
         "Hla yà:gwanhta.",
         "Nű:la! À:gwv:nv́:ga.",
-        "Agwa̋:sa wigě:dô:li dida:náɂnv̋ɂi.",
+        "Agwa̋:sa widagě:dô:li dida:náɂnv̋ɂi.",
         "À:gwv̌:ké:wa dejadó:ɂv̌:ɂi.",
         "Hihv̌:na.",
         "Dijalagi digigo:lǐ:yê:di disgwé:hyo:hv̀:ga.",

--- a/src/data/migrations/2022-08-25.ts
+++ b/src/data/migrations/2022-08-25.ts
@@ -1,6 +1,6 @@
-import { migrations } from "./all";
+import { addMigration } from "./all";
 
-migrations.push({
+addMigration({
   vhla: "v́ːhla",
   "ayo!": "ayő!",
   "v̀:hla ő:sda yi̋gi": "v́ːhla ő:sda yi̋gi.",

--- a/src/data/migrations/2022-12-16.ts
+++ b/src/data/migrations/2022-12-16.ts
@@ -1,6 +1,6 @@
-import { migrations } from "./all";
+import { addMigration } from "./all";
 
-migrations.push({
+addMigration({
   "sóhněla:du": "sóhně:la:du",
   "Agwa̋:sa wigě:dôli dida:náɂnv̋ɂi.": "Agwa̋:sa wigě:dô:li dida:náɂnv̋ɂi.",
 });

--- a/src/data/migrations/2023-03-06-phonetics-fixes.ts
+++ b/src/data/migrations/2023-03-06-phonetics-fixes.ts
@@ -1,0 +1,7 @@
+import { addMigration } from "./all";
+
+addMigration({
+  "gwiligi dù:do:ɂa achű:ja": "Gwiligi dù:do:ɂa hiɂa achű:ja.",
+  "de:jv̋ysdv dekdlǒ:hi": "De:jv̋sdv dekdlǒ:hi.",
+  "agwa̋:sa wigě:dô:li dida:náɂnv̋ɂi": "Agwa̋:sa widagě:dô:li dida:náɂnv̋ɂi.",
+});

--- a/src/data/migrations/all.ts
+++ b/src/data/migrations/all.ts
@@ -1,2 +1,12 @@
+import { cherokeeToKey } from "../cards";
+
 // null marks that term should be _deleted_
 export const migrations: Record<string, string | null>[] = [];
+
+export function addMigration(migration: Record<string, string | null>) {
+  migrations.push(
+    Object.fromEntries(
+      Object.entries(migration).map(([k, v]) => [cherokeeToKey(k), v])
+    )
+  );
+}

--- a/src/data/migrations/index.ts
+++ b/src/data/migrations/index.ts
@@ -2,6 +2,7 @@ import { cherokeeToKey } from "../cards";
 // import new migrations here
 import "./2022-08-25";
 import "./2022-12-16";
+import "./2023-03-06-phonetics-fixes";
 import { migrations } from "./all";
 
 function applyMigration(

--- a/src/index.css
+++ b/src/index.css
@@ -17,3 +17,7 @@ code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
     monospace;
 }
+
+button {
+  cursor: pointer;
+}

--- a/src/utils/phonetics.test.ts
+++ b/src/utils/phonetics.test.ts
@@ -2,6 +2,7 @@ import assert from "assert";
 import { cards } from "../data/cards";
 import { PhoneticsPreference } from "../state/reducers/phoneticsPreference";
 import {
+  alignSyllabaryAndPhonetics,
   getPhonetics,
   mcoToWebsterTones,
   normalizeAndRemovePunctuation,
@@ -93,6 +94,67 @@ describe("getPhonetics", () => {
       termsWithDiacriticsLeft,
       [],
       "there should be no terms with diacritics left"
+    );
+  });
+});
+
+describe("alignSyllabaryAndPhonetics", () => {
+  it.each([
+    ["ᎣᏏᏲ", "osiyo", ["Ꭳ", "Ꮟ", "Ᏺ"], ["o", "si", "yo"]],
+    // the following contain drop vowels
+    [
+      "ᏅᏃᎱᎵᏗ",
+      "nvnohuhldi",
+      ["Ꮕ", "Ꮓ", "Ꮁ", "Ꮅ", "Ꮧ"],
+      ["nv", "no", "hu", "hl", "di"],
+    ],
+    ["ᎠᏍᎦᏯ", "asgay", ["Ꭰ", "Ꮝ", "Ꭶ", "Ꮿ"], ["a", "s", "ga", "y"]],
+    // the below differ only in syllabary spelling
+    ["ᎢᏡᎬᎢ", "ihlgvi", ["Ꭲ", "Ꮱ", "Ꭼ", "Ꭲ"], ["i", "hl", "gv", "i"]],
+    ["ᎢᎵᎬᎢ", "ihlgvi", ["Ꭲ", "Ꮅ", "Ꭼ", "Ꭲ"], ["i", "hl", "gv", "i"]],
+    // more stuff
+    ["ᎤᏛᏛᏁ", "utvdvhne", ["Ꭴ", "Ꮫ", "Ꮫ", "Ꮑ"], ["u", "tv", "dv", "hne"]],
+    ["ᏚᏯ", "tuya", ["Ꮪ", "Ꮿ"], ["tu", "ya"]],
+    // works with / without dropped vowel
+    ["ᏗᏂᏲᏟ", "diniyotl", ["Ꮧ", "Ꮒ", "Ᏺ", "Ꮯ"], ["di", "ni", "yo", "tl"]],
+    ["ᏗᏂᏲᏟ", "diniyotli", ["Ꮧ", "Ꮒ", "Ᏺ", "Ꮯ"], ["di", "ni", "yo", "tli"]],
+    ["ᏩᏯ", "wahya", ["Ꮹ", "Ꮿ"], ["wa", "hya"]],
+    ["ᏩᎭᏯ", "wahya", ["Ꮹ", "Ꭽ", "Ꮿ"], ["wa", "h", "ya"]],
+    // ti / di stuff
+    ["ᏍᏚᏗ", "sdudi", ["Ꮝ", "Ꮪ", "Ꮧ"], ["s", "du", "di"]],
+    [
+      "ᎠᏴᏓᏆᎶᏍᎩ",
+      "a²hyv²²da²gwa²lo¹¹sgi",
+      ["Ꭰ", "Ᏼ", "Ꮣ", "Ꮖ", "Ꮆ", "Ꮝ", "Ꭹ"],
+      ["a²", "hyv²²", "da²", "gwa²", "lo¹¹", "s", "gi"],
+    ],
+  ])(
+    "works idk",
+    (syllabary, phonetics, expectedSyllabary, expectedPhonetics) => {
+      const result = alignSyllabaryAndPhonetics(syllabary, phonetics);
+      assert.deepStrictEqual(result, [
+        [expectedSyllabary],
+        [expectedPhonetics],
+      ]);
+    }
+  );
+
+  it("doesn't blow up for any terms", () => {
+    const termsThatExploded = cards.reduce<string[]>((arr, card) => {
+      try {
+        const _res = alignSyllabaryAndPhonetics(
+          card.syllabary,
+          getPhonetics(card, PhoneticsPreference.Detailed)
+        );
+      } catch (err) {
+        return [...arr, "" + err];
+      }
+      return arr;
+    }, []);
+    assert.deepStrictEqual(
+      termsThatExploded,
+      [],
+      "there should be no terms that error out"
     );
   });
 });

--- a/src/utils/phonetics.test.ts
+++ b/src/utils/phonetics.test.ts
@@ -128,6 +128,14 @@ describe("alignSyllabaryAndPhonetics", () => {
       ["Ꭰ", "Ᏼ", "Ꮣ", "Ꮖ", "Ꮆ", "Ꮝ", "Ꭹ"],
       ["a²", "hyv²²", "da²", "gwa²", "lo¹¹", "s", "gi"],
     ],
+    // handle Ꮝ prefixed s sounds
+    ["ᏍᏏᏓᏁᎳ", "sidanela", ["ᏍᏏ", "Ꮣ", "Ꮑ", "Ꮃ"], ["si", "da", "ne", "la"]],
+    ["ᏏᏓᏁᎳ", "sidanela", ["Ꮟ", "Ꮣ", "Ꮑ", "Ꮃ"], ["si", "da", "ne", "la"]],
+    // the following handle fused sounds
+    ["ᏫᎯᏢᎾ", "hwitlvna", ["ᏫᎯ", "Ꮲ", "Ꮎ"], ["hwi", "tlv", "na"]],
+    ["ᏱᎯᏍᏕᎳ", "hyisdela", ["ᏱᎯ", "Ꮝ", "Ꮥ", "Ꮃ"], ["hyi", "s", "de", "la"]],
+    // sounds are not fused if they do not need to be
+    ["ᏘᏫᎯ", "tiwihi", ["Ꮨ", "Ꮻ", "Ꭿ"], ["ti", "wi", "hi"]],
   ])(
     "works idk",
     (syllabary, phonetics, expectedSyllabary, expectedPhonetics) => {

--- a/src/utils/phonetics.test.ts
+++ b/src/utils/phonetics.test.ts
@@ -1,5 +1,5 @@
 import assert from "assert";
-import { cards } from "../data/cards";
+import { Card, cards, PhoneticOrthography } from "../data/cards";
 import { PhoneticsPreference } from "../state/reducers/phoneticsPreference";
 import {
   alignSyllabaryAndPhonetics,
@@ -152,17 +152,36 @@ describe("alignSyllabaryAndPhonetics", () => {
       try {
         const _res = alignSyllabaryAndPhonetics(
           card.syllabary,
-          getPhonetics(card, PhoneticsPreference.Detailed)
+          getPhonetics(card, PhoneticsPreference.Detailed),
+          false
         );
       } catch (err) {
-        return [...arr, "" + err];
+        return [...arr, card.cherokee];
       }
       return arr;
     }, []);
     assert.deepStrictEqual(
       termsThatExploded,
-      [],
+      // actively talking to first language speakers about this term:
+      ["e²²li³³wu³ke³ yi²ki,sde²²la, di²gv²²di²²ye³ʔv²³ʔi²"],
       "there should be no terms that error out"
     );
+  });
+
+  it("fails gracefully", () => {
+    const [syllabary, phonetics] = alignSyllabaryAndPhonetics(
+      "ᎡᎵᏭᎨ ᏱᏍᎩᏍᏕᎳ ᏗᎬᏗᏰᎥᎢ",
+      "e²²li³³wu³ke³ yi²ksde²²l di²gv²²di²²ye³ɂv²³ɂi²"
+    );
+    assert.deepStrictEqual(syllabary, [
+      ["Ꭱ", "Ꮅ", "Ꮽ", "Ꭸ"],
+      ["ᏱᏍᎩᏍᏕᎳ"],
+      ["Ꮧ", "Ꭼ", "Ꮧ", "Ᏸ", "Ꭵ", "Ꭲ"],
+    ]);
+    assert.deepStrictEqual(phonetics, [
+      ["e²²", "li³³", "wu³", "ke³"],
+      ["yi²ksde²²l"],
+      ["di²", "gv²²", "di²²", "ye³", "ɂv²³", "ɂi²"],
+    ]);
   });
 });

--- a/src/utils/phonetics.ts
+++ b/src/utils/phonetics.ts
@@ -40,6 +40,7 @@ export function normalizeAndRemovePunctuation(cherokee: string): string {
     .replaceAll(/j/g, "ts")
     .replaceAll(/qu/g, "gw")
     .replaceAll(/[Ɂʔ]/g, "ɂ")
+    .replaceAll(/ː/g, ":")
     .normalize("NFD");
 }
 
@@ -88,4 +89,167 @@ export function simplifyPhonetics({
     case PhoneticOrthography.WEBSTER:
       return simplifyWebster(normalizeAndRemovePunctuation(cherokee));
   }
+}
+
+function prototypicalSyllable(syllabary: string): string {
+  // handle Ꮝ-prefixed s sounds (eg. ᏍᏏᏉᏯ - sigwoya)
+  if (syllabary.length == 2 && syllabary.startsWith("Ꮝ"))
+    return prototypicalSyllable(syllabary[1]);
+
+  // see https://en.wikipedia.org/wiki/Cherokee_(Unicode_block)
+  if (["Ꮤ", "Ꮨ", "Ꮦ"].includes(syllabary)) return "Ꮤ";
+  if (["Ꭷ", "Ꮝ", "Ꮏ", "Ᏽ", "Ꮬ", "Ꮏ", ".", "?", ",", "!"].includes(syllabary))
+    return syllabary;
+
+  const breaks = [
+    "Ꭰ",
+    "Ꭶ",
+    "Ꭽ",
+    "Ꮃ",
+    "Ꮉ",
+    "Ꮎ",
+    "Ꮖ",
+    "Ꮜ",
+    "Ꮣ",
+    "Ꮭ",
+    "Ꮳ",
+    "Ꮹ",
+    "Ꮿ",
+  ];
+  const breakCodes = breaks.map((b) => b.charCodeAt(0));
+  const syllabaryCode = syllabary.charCodeAt(0);
+  const hit =
+    breakCodes.length -
+    1 -
+    breakCodes.reverse().findIndex((code) => code <= syllabaryCode);
+  if (hit === breakCodes.length)
+    throw new Error(
+      `Could not find prototypical representation for: ${syllabary}`
+    );
+
+  return breaks[hit];
+}
+
+function alignSyllabaryAndPhoneticsWord(
+  syllabary: string,
+  phonetics: string
+): [string[], string[]] {
+  const syllabarySounds: Record<string, RegExp> = {
+    ".": /\.?/,
+    ",": /,?/,
+    "?": /\??/,
+    "!": /\!?/,
+    Ꭰ: /[aeiouv][¹²³⁴]*/,
+    Ꭶ: /[gk]([aeiouv][¹²³⁴]*)?/,
+    Ꭷ: /k([aeiouv][¹²³⁴]*)?/,
+    Ꭽ: /h([aeiouv][¹²³⁴]*)?/,
+    Ꮃ: /[ht]?l([aeiouv][¹²³⁴]*)?/,
+    Ꮉ: /m([aeiouv][¹²³⁴]*)?/,
+    Ꮎ: /n([aeiouv][¹²³⁴]*)?/,
+    Ꮏ: /hn([aeiouv][¹²³⁴]*)?/,
+    Ꮖ: /((gw)|(qu)|(kw))([aeiouv][¹²³⁴]*)?/,
+    Ꮝ: /s(?![aeiouv])/, // s not followed by vowel
+    Ꮜ: /s([aeiouv][¹²³⁴]*)?/, // always followed by vowel
+    Ꮣ: /[td]([aeiouv][¹²³⁴]*)?/,
+    Ꮤ: /t([aei][¹²³⁴]*)?/, // ta only represents ta, ti, te
+    Ꮭ: /((tl)|(hl)|(dl))([aeiouv][¹²³⁴]*)?/, // support tla for hla
+    Ꮬ: /((tl)|(hl)|(dl))([aeiouv][¹²³⁴]*)?/, // dla
+    Ꮳ: /((j)|(ts)|(ch))([aeiouv][¹²³⁴]*)?/,
+    Ꮹ: /w([aeiouv][¹²³⁴]*)?/,
+    Ꮿ: /y([aeiouv][¹²³⁴]*)?/,
+  };
+
+  const [_remaining, splitSyllabary, splitPhonetics] = syllabary
+    .trim()
+    .split("")
+    .reduce<string[]>(
+      (fixed, nextCharacter) =>
+        prototypicalSyllable(nextCharacter) === "Ꮜ" &&
+        fixed[fixed.length - 1] === "Ꮝ"
+          ? [...fixed.slice(0, fixed.length - 1), "Ꮝ" + nextCharacter]
+          : [...fixed, nextCharacter],
+      []
+    )
+    .reduce<[string, string[], string[]]>(
+      (
+        [remainingPhonetics, splitSyllabary, splitPhonetics],
+        syllabaryCharacter
+      ) => {
+        const nextRegexp =
+          syllabarySounds[prototypicalSyllable(syllabaryCharacter)];
+        if (nextRegexp === undefined)
+          throw new Error(`No regexp found for: ${syllabaryCharacter}`);
+        const matchRes = nextRegexp.exec(remainingPhonetics);
+        if (matchRes === null)
+          throw new Error(
+            `Could not match next syllabary grapheme [${phonetics} / ${syllabary}]: ${remainingPhonetics}, ${syllabaryCharacter}, ${prototypicalSyllable(
+              syllabaryCharacter
+            )}, ${nextRegexp}`
+          );
+        const foundAt = matchRes.index;
+        const matchedPhonetics = matchRes[0];
+        if (foundAt > 1)
+          throw new Error(
+            `Match found too deep [${phonetics} / ${syllabary}]: ${remainingPhonetics} --> ${matchedPhonetics} (${nextRegexp})`
+          );
+        if (
+          foundAt === 1 &&
+          remainingPhonetics[0] !== "h" &&
+          remainingPhonetics[0] !== "ɂ"
+        )
+          throw new Error(
+            `Match expected intrusive h [${phonetics} / ${syllabary}]: ${remainingPhonetics}, ${nextRegexp}, ${splitPhonetics}`
+          );
+
+        // console.log(
+        //   remainingPhonetics,
+        //   syllabaryCharacter,
+        //   prototypicalSyllable(syllabaryCharacter),
+        //   matchedPhonetics
+        // );
+        return [
+          remainingPhonetics.substring(matchedPhonetics.length + foundAt),
+          [...splitSyllabary, syllabaryCharacter],
+          [
+            ...splitPhonetics,
+            remainingPhonetics.substring(0, matchedPhonetics.length + foundAt),
+          ],
+        ];
+      },
+      [phonetics.trim(), [], []]
+    );
+
+  // rest: do the thing shit...
+  return [splitSyllabary, splitPhonetics];
+}
+
+export function alignSyllabaryAndPhonetics(
+  syllabary: string,
+  phonetics: string
+): [string[][], string[][]] {
+  const syllabaryWords = syllabary
+    .trim()
+    .split(" ")
+    .filter((w) => w.trim() !== "");
+  const phoneticsWords = phonetics
+    .trim()
+    .split(" ")
+    .filter((w) => w.trim() !== "");
+
+  if (syllabaryWords.length !== phoneticsWords.length)
+    throw new Error(
+      `Not the same number of words in syllabary and phonetics!\n\t${syllabary}\n\t${phonetics}`
+    );
+
+  return syllabaryWords.reduce<[string[][], string[][]]>(
+    ([syllabarySplit, phoneticsSplit], syllabaryWord, idx) => {
+      const [newSyllabarySplit, newPhoneticsSplit] =
+        alignSyllabaryAndPhoneticsWord(syllabaryWord, phoneticsWords[idx]);
+      return [
+        [...syllabarySplit, newSyllabarySplit],
+        [...phoneticsSplit, newPhoneticsSplit],
+      ];
+    },
+    [[], []]
+  );
 }

--- a/src/utils/phonetics.ts
+++ b/src/utils/phonetics.ts
@@ -243,9 +243,17 @@ function alignSyllabaryAndPhoneticsWord(
   return [splitSyllabary, splitPhonetics];
 }
 
+/**
+ * Present an array of aligned segments for syllabary and phonetics.
+ * @param syllabary
+ * @param phonetics
+ * @param suppressErrors - if true words that fail to be matched will be aligned with syllabary on a per word basis.
+ * @returns `[syllabaryWords, phoneticsWords]`, where each `*Words` array contains a list of string segements.
+ */
 export function alignSyllabaryAndPhonetics(
   syllabary: string,
-  phonetics: string
+  phonetics: string,
+  suppressErrors = true
 ): [string[][], string[][]] {
   const syllabaryWords = syllabary
     .trim()
@@ -263,12 +271,23 @@ export function alignSyllabaryAndPhonetics(
 
   return syllabaryWords.reduce<[string[][], string[][]]>(
     ([syllabarySplit, phoneticsSplit], syllabaryWord, idx) => {
-      const [newSyllabarySplit, newPhoneticsSplit] =
-        alignSyllabaryAndPhoneticsWord(syllabaryWord, phoneticsWords[idx]);
-      return [
-        [...syllabarySplit, newSyllabarySplit],
-        [...phoneticsSplit, newPhoneticsSplit],
-      ];
+      try {
+        const [newSyllabarySplit, newPhoneticsSplit] =
+          alignSyllabaryAndPhoneticsWord(syllabaryWord, phoneticsWords[idx]);
+        return [
+          [...syllabarySplit, newSyllabarySplit],
+          [...phoneticsSplit, newPhoneticsSplit],
+        ];
+      } catch (e) {
+        if (suppressErrors) {
+          return [
+            [...syllabarySplit, [syllabaryWord]],
+            [...phoneticsSplit, [phoneticsWords[idx]]],
+          ];
+        } else {
+          throw e;
+        }
+      }
     },
     [[], []]
   );


### PR DESCRIPTION
## Stories and tasks
Closes #66 and closes #67 

https://user-images.githubusercontent.com/5622360/223211803-de11360e-6eb6-4090-9011-64002d253c8e.mov

## TODO
- [ ] ᏱᏍᎩᏍᏕᎳ / yiksdel still cannot be matched. I am talking to JW about what is up with `sgis` being shortened to `ks`

## Commits
- align phonetics and syllabary and let user mouseover to see connection
- handle fused sounds
- present aligned phonetics to user
- syllabary changes needed (phonetics changes need migration)
- migrate terms that needed phonetics changes
